### PR TITLE
feat: update to bifrost-cli v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ jobs:
           retry-delay: '10'
 ```
 
+### Container Image Version Inference
+
+Provide `image` when the SBOM belongs to a container image. `service-version` is optional when `image` is provided.
+
+```yaml
+      - name: Send image SBOM to bifrost
+        uses: bifrostsec/submit-sbom-action@v1
+        with:
+          api-token: ${{ secrets.BIFROST_API_TOKEN }}
+          service: 'my-service'
+          image: 'ghcr.io/example/my-service:v1.0.0'
+          sbom-path: 'build/image.cdx.json'
+```
+
 ### Multiple SBOM Files
 
 Provide `sbom-path` as a multiline value to upload multiple SBOM files in one action invocation:
@@ -125,7 +139,8 @@ Use GitHub's dependency graph export as an additional SBOM source:
 |--------------------|----------------------------------------------|----------|-------------------|------------------------------------------------|
 | `api-token`        | Bearer token for Bifrost API authentication  | Yes      | -                 | -                                              |
 | `service`          | Your Service name                            | Yes      | -                 | -                                              |
-| `service-version`  | Your Service version                         | Yes      | -                 | -                                              |
+| `service-version`  | Your Service version                         | Conditional | -              | Required unless `image` is provided            |
+| `image`            | Container image reference                    | Conditional | -              | Required unless `service-version` is provided  |
 | `sbom-path`        | Path to the SBOM file to submit, or a multiline list of SBOM paths | No | - | When unset and `dependency-graph` is `true`, only the dependency graph SBOM is submitted |
 | `dependency-graph` | Export the GitHub dependency graph SBOM      | No       | `false`           | Uses the current repository default branch     |
 | `retry-attempts`   | Number of retry attempts for failed requests | No       | `3`               | -                                              |
@@ -144,14 +159,15 @@ This action does not provide explicit output values. Instead, it uses GitHub Act
 This action submits SBOMs to the Bifrost API using `bifrost-cli`, which calls the following endpoint:
 
 ``` 
-POST https://portal.bifrostsec.com/api/v2/service/{service}/version/{version}/sbom
+POST https://portal.bifrostsec.com/api/v2/service/{service}/version/sbom
 ```
 
 The request includes:
 - `Authorization: Bearer {api-token}` header
 - `Content-Type: application/json` header
 - SBOM file contents as the request body
-- Git metadata query parameters: `git_branch`, `git_commit_sha`, and `git_origin`
+- `version` and/or `image` query parameters
+- Git metadata query parameters detected by `bifrost-cli` from the GitHub workspace when a checkout is available: `git_branch`, `git_commit_sha`, and `git_origin`
 
 Read the [bifrost API documentation](https://docs.bifrostsec.com/api/v2/) for more details on authentication and request formats.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ jobs:
 
 ### Container Image Version Inference
 
-Provide `image` when the SBOM belongs to a container image. `service-version` is optional when `image` is provided.
+Provide `image` when the SBOM belongs to a container image. `service-version` is optional when `image` is provided, the version name will then be derived from the image tag (both can be provided).
 
 ```yaml
       - name: Send image SBOM to bifrost

--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,10 @@ inputs:
     description: Service name
     required: true
   service-version:
-    description: Service version
-    required: true
+    description: Service version. Required unless image is provided.
+    required: false
   image:
-    description: 'DEPRECATED: Container image name (accepted, but ignored)'
+    description: Container image reference. Required unless service-version is provided.
     required: false
   sbom-path:
     description: >-
@@ -40,11 +40,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Warn About Deprecated Inputs
-      if: ${{ inputs.image != '' }}
-      shell: bash
-      run: echo '::warning::Input "image" is accepted, but ignored.'
-
     - name: Warn When No SBOM Source Is Configured
       if: ${{ inputs.sbom-path == '' && inputs.dependency-graph != 'true' }}
       shell: bash
@@ -73,13 +68,12 @@ runs:
         ACTION_API_TOKEN: ${{ inputs.api-token }}
         ACTION_SERVICE: ${{ inputs.service }}
         ACTION_SERVICE_VERSION: ${{ inputs.service-version }}
+        ACTION_IMAGE: ${{ inputs.image }}
         ACTION_SBOM_PATH: ${{ inputs.sbom-path }}
         ACTION_DEPENDENCY_GRAPH_SBOM_PATH: ${{ steps.dependency-graph-sbom.outputs.dependency_graph_sbom_path }}
         ACTION_RETRY_ATTEMPTS: ${{ inputs.retry-attempts }}
         ACTION_RETRY_DELAY: ${{ inputs.retry-delay }}
         ACTION_API_HOST: ${{ inputs.api-host }}
-        ACTION_GIT_BRANCH: ${{ github.ref_name }}
-        ACTION_GIT_COMMIT_SHA: ${{ github.sha }}
-        ACTION_GIT_ORIGIN: ${{ github.server_url }}/${{ github.repository }}
+        ACTION_GIT_REPO_PATH: ${{ github.workspace }}
         CLI_PATH: ${{ steps.install-cli.outputs.cli_path }}
       run: bash "$GITHUB_ACTION_PATH/scripts/upload-sbom.sh"

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -2,33 +2,33 @@
 
 set -euo pipefail
 
-cli_version="v0.2.2"
+cli_version="v0.3.1"
 
 # Release asset and pinned checksum per runner platform; update together with cli_version.
 case "${RUNNER_OS}:${RUNNER_ARCH}" in
   Linux:X64)
     asset_name="bifrost-linux-amd64"
-    expected_sha="516eaf892818d6a5f406dd10ce44ccd5b68546399b705d9dc0d5b711d2f4b9d1"
+    expected_sha="174d394a04eee09588127c871f84c608c14b7d3a1a70611b8b327cb017f27445"
     ;;
   Linux:ARM64)
     asset_name="bifrost-linux-arm64"
-    expected_sha="73aa3e3e20d1aa5bcd09740074503fd32b49bb05c8d935dbf099b602475628c1"
+    expected_sha="0b7f4c61ee4ed810511479a93c9325c3f84dc99340b6375be97dc09603a440e5"
     ;;
   macOS:X64)
     asset_name="bifrost-darwin-amd64"
-    expected_sha="7c494b2bc4036d1fe90a7f75a7d2b6377bd7185ed8c80f9095bae405438901f6"
+    expected_sha="3a4adb907487b56fb88c51b8546bf39031efd6d1cac0bef499db75eb1fe44f5d"
     ;;
   macOS:ARM64)
     asset_name="bifrost-darwin-arm64"
-    expected_sha="ca57a447c399340349ef9530ee5874350178d834671b5207d1bd918861c6e5bb"
+    expected_sha="89638d6465ca8af0846cded855e48b2d242d51f0e4c7522a69c660c63d3fd1dc"
     ;;
   Windows:X64)
     asset_name="bifrost-windows-amd64"
-    expected_sha="7b1c340b963bd37353849041ea0ab4e7a65a1fa00c3a8bb92327ab2ca4b1abaa"
+    expected_sha="7c7473ab0e209ea7a93e7f152d38e915a464eb317675788d931aefbf3f64df20"
     ;;
   Windows:X86)
     asset_name="bifrost-windows-386"
-    expected_sha="b109c58a683061b55fc8dc7e04e1bc5691e0f15f256f204ce87136168eb41c83"
+    expected_sha="6fafec53b0f796977eaabe3e2fea1d1d744fc39d18f8012cbe9734dfdab9a37c"
     ;;
   *)
     echo "::error::Unsupported runner platform: ${RUNNER_OS}/${RUNNER_ARCH}"

--- a/scripts/upload-sbom.sh
+++ b/scripts/upload-sbom.sh
@@ -23,22 +23,21 @@ fi
 
 args=(
   "--service=${ACTION_SERVICE}"
-  "--service-version=${ACTION_SERVICE_VERSION}"
 )
+if [ -n "${ACTION_SERVICE_VERSION:-}" ]; then
+  args+=("--service-version=${ACTION_SERVICE_VERSION}")
+fi
+if [ -n "${ACTION_IMAGE:-}" ]; then
+  args+=("--image=${ACTION_IMAGE}")
+fi
 if [ -n "${ACTION_RETRY_ATTEMPTS}" ]; then
   args+=("--retry-attempts=${ACTION_RETRY_ATTEMPTS}")
 fi
 if [ -n "${ACTION_RETRY_DELAY}" ]; then
   args+=("--retry-delay=${ACTION_RETRY_DELAY}s")
 fi
-if [ -n "${ACTION_GIT_BRANCH:-}" ]; then
-  args+=("--git-branch=${ACTION_GIT_BRANCH}")
-fi
-if [ -n "${ACTION_GIT_COMMIT_SHA:-}" ]; then
-  args+=("--git-commit-sha=${ACTION_GIT_COMMIT_SHA}")
-fi
-if [ -n "${ACTION_GIT_ORIGIN:-}" ]; then
-  args+=("--git-origin=${ACTION_GIT_ORIGIN}")
+if [ -n "${ACTION_GIT_REPO_PATH:-}" ]; then
+  args+=("--git-repo-path=${ACTION_GIT_REPO_PATH}")
 fi
 
 BIFROST_API_KEY="${ACTION_API_TOKEN}" \

--- a/scripts/upload-sbom.sh
+++ b/scripts/upload-sbom.sh
@@ -21,6 +21,11 @@ if [ "${#sbom_paths[@]}" -eq 0 ]; then
   exit 1
 fi
 
+if [ -z "${ACTION_SERVICE_VERSION:-}" ] && [ -z "${ACTION_IMAGE:-}" ]; then
+  echo "::error::Either service-version or image must be provided."
+  exit 1
+fi
+
 args=(
   "--service=${ACTION_SERVICE}"
 )
@@ -30,10 +35,10 @@ fi
 if [ -n "${ACTION_IMAGE:-}" ]; then
   args+=("--image=${ACTION_IMAGE}")
 fi
-if [ -n "${ACTION_RETRY_ATTEMPTS}" ]; then
+if [ -n "${ACTION_RETRY_ATTEMPTS:-}" ]; then
   args+=("--retry-attempts=${ACTION_RETRY_ATTEMPTS}")
 fi
-if [ -n "${ACTION_RETRY_DELAY}" ]; then
+if [ -n "${ACTION_RETRY_DELAY:-}" ]; then
   args+=("--retry-delay=${ACTION_RETRY_DELAY}s")
 fi
 if [ -n "${ACTION_GIT_REPO_PATH:-}" ]; then


### PR DESCRIPTION
Update to use the latest bifrost-cli version `v0.3.1`
- Support `image` as an alternative to `service-version` when submitting container image SBOMs
- Pass repository path to `bifrost-cli` for automatic Git metadata detection (instead of the action providing it manually)
- Upgrade `bifrost-cli` to v0.3.1 with updated platform checksums
- Update action documentation and input descriptions